### PR TITLE
Fixed imports on Examples on readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ To train a Soft Actor-Critic model from scratch on the `Pendulum-v0` gym environ
 ```python
 import gym
 
-from genrl import SAC, QLearning
-from genrl.classical.common import Trainer
-from genrl.deep.common import OffPolicyTrainer
+from genrl.agents.deep.sac.sac import SAC
+from genrl.trainers.base import Trainer
+from genrl.trainers.offpolicy import OffPolicyTrainer
 from genrl.environments import VectorEnv
 
 env = VectorEnv("Pendulum-v0")
@@ -68,10 +68,14 @@ trainer.train()
 
 To train a Tabular Dyna-Q model from scratch on the `FrozenLake-v0` gym environment and plot rewards:
 ```python
+import gym
+
+from genrl.agents.classical.qlearning.qlearning import QLearning
+from genrl.trainers.classical import ClassicalTrainer
 
 env = gym.make("FrozenLake-v0")
 agent = QLearning(env)
-trainer = Trainer(agent, env, mode="dyna", model="tabular", n_episodes=10000)
+trainer = ClassicalTrainer(agent, env, mode="dyna", model="tabular", n_episodes=10000)
 episode_rewards = trainer.train()
 trainer.plot(episode_rewards)
 ```

--- a/examples/hyperparameters/optuna/a2c_cartpole-v0.py
+++ b/examples/hyperparameters/optuna/a2c_cartpole-v0.py
@@ -58,7 +58,7 @@ def tune_A2C(trial):
                     episode_reward[i] = 0
         if episode == trainer.evaluate_episodes:
             print(
-                "Evaluated for {} episodes, Mean Reward: {}, Std Deviation for the Reward: {}".format(
+                "Evaluated for {} episodes, Mean Reward: {:.2f}, Std Deviation for the Reward: {:.2f}".format(
                     trainer.evaluate_episodes,
                     np.mean(episode_rewards),
                     np.std(episode_rewards),

--- a/genrl/trainers/base.py
+++ b/genrl/trainers/base.py
@@ -114,7 +114,7 @@ class Trainer(ABC):
                         episode_reward[i] = 0
             if episode == self.evaluate_episodes:
                 print(
-                    "Evaluated for {} episodes, Mean Reward: {}, Std Deviation for the Reward: {}".format(
+                    "Evaluated for {} episodes, Mean Reward: {:.2f}, Std Deviation for the Reward: {:.2f}".format(
                         self.evaluate_episodes,
                         np.mean(episode_rewards),
                         np.std(episode_rewards),

--- a/genrl/trainers/classical.py
+++ b/genrl/trainers/classical.py
@@ -166,7 +166,7 @@ class ClassicalTrainer:
                 mean_ep_rew = np.mean(ep_rews)
                 if ep == 100:
                     print(
-                        "Evaluating on {} episodes, Mean Reward: {} and Std Deviation for the reward: {}".format(
+                        "Evaluated for {} episodes, Mean Reward: {:.2f}, Std Deviation for the Reward: {:.2f}".format(
                             eval_ep, mean_ep_rew, np.std(ep_rews)
                         )
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ matplotlib==3.2.1
 pytest==5.4.1
 torch==1.4.0
 torchvision==0.5.0
-tensorflow-tensorboard==1.5.1
 tensorboard==1.15.0
 pre-commit==2.4.0
 importlib-resources==1.0.1


### PR DESCRIPTION
When installing the **genrl** library and tried to run the example programs there were some issues.

- `tensorflow-tensorboard==1.5.1` was causing issues with the `tensorboard==1.15.0` library. This is most likely due to the fact that tensorflow-tensorboard has been [deprecated](https://pypi.org/project/tensorflow-tensorboard/). This is the reason why I've removed it from the requirements.txt
- Imports for example programs weren't working, so suggested changes (they have been tested).
