### PR TITLE
Change numpy array to tensor in vpg.py

### DIFF
--- a/genrl/agents/deep/vpg/vpg.py
+++ b/genrl/agents/deep/vpg/vpg.py
@@ -111,7 +111,7 @@ class VPG(OnPolicyAgent):
             values (:obj:`torch.Tensor`): Values of states encountered during the rollout
             dones (:obj:`list` of bool): Game over statuses of each environment
         """
-        self.rollout.compute_returns_and_advantage(values.detach().cpu().numpy(), dones)
+        self.rollout.compute_returns_and_advantage(values.detach().clone(), dones)
 
     def update_params(self) -> None:
         """Updates the the A2C network


### PR DESCRIPTION
The actual function (compute_returns_and_advantage) expects ﻿a torch.tensor but was being passed a numpy.ndarray
Fixes #316 
