### PR TITLE
Separate Workflows

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -1,0 +1,86 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        python-version: [ '3.6','3.7','3.8' ]
+        platform: [ubuntu-20.04]
+    runs-on: ${{ matrix.platform }}
+    
+    name: Python ${{ matrix.python-version }} - ${{ matrix.platform }}
+       
+    steps:
+      # Caching Linux
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Caching MacOS
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Caching Windows
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Setup
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+      
+      - name: Update conda env dependencies
+        shell: bash -l {0}
+        run: |
+          conda config --set ssl_verify no
+          conda install pytorch==1.4.0 torchvision==0.5.0 cpuonly -c pytorch
+          pip install -f https://github.com/Kojoley/atari-py/releases atari_py
+          conda env update environment.yml
+
+      # Install Dependencies
+      - name: Install Windows dependencies
+        shell: pwsh
+        if: startsWith(runner.os, 'Windows')
+        run: |
+          ./.scripts/windows_cpu_build.ps1
+
+      - name: Install Linux Dependencies
+        shell: bash -l {0}
+        if: startsWith(runner.os, 'macOS') || startsWith(runner.os, 'Linux')
+        run: |
+          ./.scripts/unix_cpu_build.sh
+
+      - name: Tests
+        shell: bash -l {0}
+        run: |
+          conda activate test
+          pytest --durations=0

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests Linux
 
 on:
   push:

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -1,0 +1,86 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    strategy:
+      matrix:
+        python-version: [ '3.6','3.7','3.8' ]
+        platform: [macOS-10.15]
+    runs-on: ${{ matrix.platform }}
+    
+    name: Python ${{ matrix.python-version }} - ${{ matrix.platform }}
+       
+    steps:
+      # Caching Linux
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Caching MacOS
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: ~/Library/Caches/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Caching Windows
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # Setup
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+      
+      - name: Update conda env dependencies
+        shell: bash -l {0}
+        run: |
+          conda config --set ssl_verify no
+          conda install pytorch==1.4.0 torchvision==0.5.0 cpuonly -c pytorch
+          pip install -f https://github.com/Kojoley/atari-py/releases atari_py
+          conda env update environment.yml
+
+      # Install Dependencies
+      - name: Install Windows dependencies
+        shell: pwsh
+        if: startsWith(runner.os, 'Windows')
+        run: |
+          ./.scripts/windows_cpu_build.ps1
+
+      - name: Install Linux Dependencies
+        shell: bash -l {0}
+        if: startsWith(runner.os, 'macOS') || startsWith(runner.os, 'Linux')
+        run: |
+          ./.scripts/unix_cpu_build.sh
+
+      - name: Tests
+        shell: bash -l {0}
+        run: |
+          conda activate test
+          pytest --durations=0

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests MacOS
 
 on:
   push:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Tests Windows
 
 on:
   push:

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.6','3.7','3.8' ]
-        platform: [ubuntu-20.04, windows-2019, macOS-10.15]
+        platform: [windows-2019]
     runs-on: ${{ matrix.platform }}
     
     name: Python ${{ matrix.python-version }} - ${{ matrix.platform }}
@@ -69,7 +69,6 @@ jobs:
       # Install Dependencies
       - name: Install Windows dependencies
         shell: pwsh
-        if: startsWith(runner.os, 'Windows')
         run: |
           ./.scripts/windows_cpu_build.ps1
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@
 
 [![Build Status](https://travis-ci.com/SforAiDl/genrl.svg?branch=master)](https://travis-ci.com/SforAiDl/genrl)
 [![Documentation Status](https://readthedocs.org/projects/genrl/badge/?version=latest)](https://genrl.readthedocs.io/en/latest/?badge=latest)
-![Tests](https://github.com/SforAiDl/genrl/workflows/Tests/badge.svg)
+![Tests MacOS](https://github.com/SforAiDl/genrl/workflows/Tests%20MacOS/badge.svg)
+![Tests Linux](https://github.com/SforAiDl/genrl/workflows/Tests%20Linux/badge.svg)
+![Tests Windows](https://github.com/SforAiDl/genrl/workflows/Tests%20Windows/badge.svg)
 
 [![Slack - Chat](https://img.shields.io/badge/Slack-Chat-blueviolet)](https://join.slack.com/t/genrlworkspace/shared_invite/zt-gwlgnymd-Pw3TYC~0XDLy6VQDml22zg)
 


### PR DESCRIPTION
Jobs often fail and we have to restart them. Separating them should be easier as it would involve only restarting for that OS type.