### PR TITLE
importlib versioning issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,6 +19,7 @@ tensorflow-tensorboard==1.5.1
 tensorboard==1.15.0
 pre-commit==2.4.0
 importlib-resources==1.0.1
+importlib-metadata==1.7.0
 setuptools==41.0.0
 
 # Docs dependencies


### PR DESCRIPTION
`importlib-metadata==2.0.0` fails [readthedocs build](https://readthedocs.org/projects/genrl/builds/11947025/)